### PR TITLE
Use correct glob for filtering js files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ var uglify = require('gulp-uglify');
 var rename = require('gulp-rename');
 var sourcemaps = require('gulp-sourcemaps');
 var livereload = require('gulp-livereload');
-var jsFilter = require('gulp-filter')(['*.js'], { restore: true });
+var jsFilter = require('gulp-filter')(['**/*.js'], { restore: true });
 
 gulp.task('scripts:minify', function () {
 


### PR DESCRIPTION
In former versions of gulp-filter it was possible to specify a filepattern like `*.js` which does not work for gulp-filter-4.0.0 (where there are no files at all filtered with this pattern).