### PR TITLE
Update jquery-resizable.js

### DIFF
--- a/src/jquery-resizable.js
+++ b/src/jquery-resizable.js
@@ -63,6 +63,11 @@ Licensed under MIT License
             };
 
             function startDragging(e) {
+                // Prevent dragging a ghost image in HTML5 / Firefox and maybe others    
+                if ( e.preventDefault ) {
+                  e.preventDefault();
+                }
+                
                 startPos = getMousePos(e);
                 startPos.width = parseInt($el.width(), 10);
                 startPos.height = parseInt($el.height(), 10);


### PR DESCRIPTION
Prevent dragging a ghost image in HTML5 / Firefox and maybe others. 

In HTML5 images are now draggable which means that after N pixels Firefox and Chrome start dragging the image as though the user were dragging it to their desktop or something. 

Preventing default makes it work the way it should. 

See it with the fix here:
http://codepen.io/stuporglue/pen/ZeLQaw

And without it here: 
http://codepen.io/stuporglue/pen/ZeLprw