### PR TITLE
a 'destroy' command to remove resizable instances

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,6 +152,17 @@ Hook event fired when the drag operation completes and the mouse is released. Re
 Sets touch-action: none on the handle element to prevent browser interference to initiating touch drag operations especially on Internet Explorer, Edge and Windows 10 browsers.
 
 
+### Commands
+
+**destroy**
+
+Should the need arise, you can remove a `resizable` instance with:
+
+```javascript
+  $el.resizable('destroy');
+```
+
+
 ## jquery-resizableTableColumns Plugin
 
 ### Usage

--- a/src/jquery-resizable.js
+++ b/src/jquery-resizable.js
@@ -61,15 +61,18 @@ Licensed under MIT License
 
             var $el = $(this);
 
-            var $handle = getHandle(opt.handleSelector, $el);
-
             if (options === 'destroy') {
-                $el.removeClass("resizable");
-                $handle.unbind('mousedown.rsz touchstart.rsz', startDragging);
+                var $handle = getHandle($el.data('resizable').handleSelector, $el);
+                $handle.unbind('mousedown.rsz touchstart.rsz');
                 if (opt.touchActionNone)
                     $handle.css("touch-action", "");
+                $el.removeClass("resizable");
                 return;
             }
+          
+            $el.data('resizable', opt);
+
+            var $handle = getHandle(opt.handleSelector, $el);
 
             if (opt.touchActionNone)
                 $handle.css("touch-action", "none");

--- a/src/jquery-resizable.js
+++ b/src/jquery-resizable.js
@@ -63,6 +63,14 @@ Licensed under MIT License
 
             var $handle = getHandle(opt.handleSelector, $el);
 
+            if (options === 'destroy') {
+                $el.removeClass("resizable");
+                $handle.unbind('mousedown.rsz touchstart.rsz', startDragging);
+                if (opt.touchActionNone)
+                    $handle.css("touch-action", "");
+                return;
+            }
+
             if (opt.touchActionNone)
                 $handle.css("touch-action", "none");
 


### PR DESCRIPTION
Hi Rick

I agree, hard to find a decent generic 'resizer' (found yours after during a fairly thorough search), so thank you for that plugin!

Here a few lines of code to allow removing the `resizable` instance: creating a `resizable` modifies the target element (class `resizable` and `style` attribute in particular),  for some use cases it is important to restore the original state once the editing is complete.

Greetings from Europe (wouldn't mind Hawaii's weather right now...)